### PR TITLE
add mysql and redis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ This project contains the following applications (more applications are ong the 
 
 ### Build
 
-#### Build docker image
+#### Build docker image using docker-compose
+
+You can use docker-compose to build docker images:
+
+```sh
+docker-compose build
+```
+
+#### Build docker image using scripts
 
 You need to go to the `src` directory, for each sub module, there is a `build.sh`  file, just run it to build the docker image for each module.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,47 @@ services:
     ports:
     - "8848:8848"
 
+#  currency-mysql:
+#    image: mysql:5.6
+#    ports:
+#      - 3306
+#    command: [
+#      --character-set-server=utf8mb4,
+#      --collation-server=utf8mb4_unicode_ci
+#    ]
+#    environment:
+#      MYSQL_ROOT_PASSWORD: currencyservice
+#      MYSQL_DATABASE: currency
+
+  checkout-mysql:
+    image: mysql:5.6
+    ports:
+      - 3306
+    command: [
+      --character-set-server=utf8mb4,
+      --collation-server=utf8mb4_unicode_ci
+    ]
+    environment:
+      MYSQL_ROOT_PASSWORD: checkoutservice
+      MYSQL_DATABASE: checkout
+      
+  product-mysql:
+    image: mysql:5.6
+    ports:
+      - 3306
+    command: [
+      --character-set-server=utf8mb4,
+      --collation-server=utf8mb4_unicode_ci
+    ]
+    environment:
+      MYSQL_ROOT_PASSWORD: productservice
+      MYSQL_DATABASE: product
+
+  cart-redis:
+    image: redis
+    ports:
+      - 6379:6379
+
   frontend:
     build: ./src/frontend
     image: frontend:1.0.0-SNAPSHOT
@@ -25,6 +66,7 @@ services:
       - "nacos"
 
   cartservice:
+    build: ./src/cartservice
     image: cartservice:1.0.0-SNAPSHOT
     container_name: cartservice
     environment:
@@ -33,6 +75,7 @@ services:
       - spring.cloud.nacos.config.server-addr=nacos:8848
     depends_on:
       - "nacos"
+      - "cart-redis"
 
   checkoutservice:
     build: ./src/checkoutservice
@@ -44,6 +87,7 @@ services:
     - spring.cloud.nacos.config.server-addr=nacos:8848
     depends_on:
       - "nacos"
+      - "checkout-mysql"
 
   prdoctservice:
     build: ./src/productservice
@@ -55,6 +99,7 @@ services:
     - spring.cloud.nacos.config.server-addr=nacos:8848
     depends_on:
       - "nacos"
+      - "product-mysql"
 
 #  adservice:
 #    build: ./src/adservice

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -21,3 +21,26 @@ spec:
             value: "nacos:8848"
           - name: spring.cloud.nacos.config.server-addr
             value: "nacos:8848"
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart-redis
+spec:
+  selector:
+    matchLabels:
+      app: cart-redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cart-redis
+    spec:
+      containers:
+        - name: cart-redis
+          image: redis
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -21,3 +21,35 @@ spec:
             value: "nacos:8848"
           - name: spring.cloud.nacos.config.server-addr
             value: "nacos:8848"
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-mysql
+spec:
+  selector:
+    matchLabels:
+      app: checkout-mysql
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: checkout-mysql
+    spec:
+      containers:
+        - args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
+          env:
+            - name: MYSQL_DATABASE
+              value: checkout
+            - name: MYSQL_ROOT_PASSWORD
+              value: checkoutservice
+          image: mysql:5.6
+          name: checkout-mysql
+          ports:
+            - containerPort: 3306

--- a/kubernetes-manifests/productservice.yaml
+++ b/kubernetes-manifests/productservice.yaml
@@ -22,3 +22,35 @@ spec:
               value: "nacos:8848"
             - name: spring.cloud.nacos.config.server-addr
               value: "nacos:8848"
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-mysql
+spec:
+  selector:
+    matchLabels:
+      app: product-mysql
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: product-mysql
+    spec:
+      containers:
+        - args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
+          env:
+            - name: MYSQL_DATABASE
+              value: product
+            - name: MYSQL_ROOT_PASSWORD
+              value: productservice
+          image: mysql:5.6
+          name: product-mysql
+          ports:
+            - containerPort: 3306

--- a/kubernetes-manifests/quick-start/application.yaml
+++ b/kubernetes-manifests/quick-start/application.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productservice
+spec:
+  selector:
+    matchLabels:
+      app: productservice
+  template:
+    metadata:
+#      annotations:
+#        armsPilotAutoEnable: "on"
+#        armsPilotCreateAppName: "productservice"
+      labels:
+        app: productservice
+        version: 1.0.0-SNAPSHOT
+    spec:
+      containers:
+        - name: productservice
+          image: registry.cn-beijing.aliyuncs.com/xfguo/test/productservice:1.0.0-SNAPSHOT
+          imagePullPolicy: Always
+          env:
+            - name: dubbo.registry.address
+              value: "nacos://nacos:8848"
+            - name: spring.cloud.nacos.discovery.server-addr
+              value: "nacos:8848"
+            - name: spring.cloud.nacos.config.server-addr
+              value: "nacos:8848"
+#          resources:
+#            limits:
+#              cpu: 1000m
+#              memory: 2048Mi
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cartservice
+spec:
+  selector:
+    matchLabels:
+      app: cartservice
+  template:
+    metadata:
+#      annotations:
+#        armsPilotAutoEnable: "on"
+#        armsPilotCreateAppName: "cartservice"
+      labels:
+        app: cartservice
+    spec:
+      containers:
+        - name: cartservice
+          image: registry.cn-beijing.aliyuncs.com/xfguo/test/cartservice:1.0.0-SNAPSHOT
+          imagePullPolicy: Always
+          env:
+            - name: dubbo.registry.address
+              value: "nacos://nacos:8848"
+            - name: spring.cloud.nacos.discovery.server-addr
+              value: "nacos:8848"
+            - name: spring.cloud.nacos.config.server-addr
+              value: "nacos:8848"
+#          resources:
+#            limits:
+#              cpu: 1000m
+#              memory: 2048Mi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkoutservice
+spec:
+  selector:
+    matchLabels:
+      app: checkoutservice
+  template:
+    metadata:
+#      annotations:
+#        armsPilotAutoEnable: "on"
+#        armsPilotCreateAppName: "checkoutservice"
+      labels:
+        app: checkoutservice
+    spec:
+      containers:
+        - name: checkoutservice
+          image: registry.cn-beijing.aliyuncs.com/xfguo/test/checkoutservice:1.0.0-SNAPSHOT
+          imagePullPolicy: Always
+          env:
+            - name: dubbo.registry.address
+              value: "nacos://nacos:8848"
+            - name: spring.cloud.nacos.discovery.server-addr
+              value: "nacos:8848"
+            - name: spring.cloud.nacos.config.server-addr
+              value: "nacos:8848"
+#          resources:
+#            limits:
+#              cpu: 1000m
+#              memory: 2048Mi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+#      annotations:
+#        armsPilotAutoEnable: "on"
+#        armsPilotCreateAppName: "frontend"
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: registry.cn-beijing.aliyuncs.com/xfguo/test/frontend:1.0.0-SNAPSHOT
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: dubbo.registry.address
+              value: "nacos://nacos:8848"
+            - name: spring.cloud.nacos.discovery.server-addr
+              value: "nacos:8848"
+            - name: spring.cloud.nacos.config.server-addr
+              value: "nacos:8848"
+#          resources:
+#            limits:
+#              cpu: 1000m
+#              memory: 2048Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/kubernetes-manifests/quick-start/db.yaml
+++ b/kubernetes-manifests/quick-start/db.yaml
@@ -1,0 +1,130 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart-redis
+spec:
+  selector:
+    matchLabels:
+      app: cart-redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cart-redis
+    spec:
+      containers:
+        - name: cart-redis
+          image: redis
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-mysql
+spec:
+  selector:
+    matchLabels:
+      app: checkout-mysql
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: checkout-mysql
+    spec:
+      containers:
+        - args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
+          env:
+            - name: MYSQL_DATABASE
+              value: checkout
+            - name: MYSQL_ROOT_PASSWORD
+              value: checkoutservice
+          image: mysql:5.6
+          name: checkout-mysql
+          ports:
+            - containerPort: 3306
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-mysql
+spec:
+  selector:
+    matchLabels:
+      app: product-mysql
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: product-mysql
+    spec:
+      containers:
+        - args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
+          env:
+            - name: MYSQL_DATABASE
+              value: product
+            - name: MYSQL_ROOT_PASSWORD
+              value: productservice
+          image: mysql:5.6
+          name: product-mysql
+          ports:
+            - containerPort: 3306
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cart-redis
+  name: cart-redis
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: cart-redis
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: checkout-mysql
+  name: checkout-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+    app: checkout-mysql
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: product-mysql
+  name: product-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+    app: product-mysql

--- a/kubernetes-manifests/quick-start/nacos.yaml
+++ b/kubernetes-manifests/quick-start/nacos.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nacos
+spec:
+  selector:
+    matchLabels:
+      app: nacos
+  template:
+    metadata:
+      labels:
+        app: nacos
+    spec:
+      containers:
+        - name: nacos-standalone
+          image: nacos/nacos-server:latest
+          ports:
+            - containerPort: 8848
+          env:
+            - name: PREFER_HOST_MODE
+              value: "hostname"
+            - name: MODE
+              value: "standalone"
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nacos
+spec:
+  type: ClusterIP
+  selector:
+    app: nacos
+  ports:
+    - name: http
+      port: 8848
+      targetPort: 8848

--- a/src/cartservice/cartservice-interface/src/main/java/com/alibabacloud/hipstershop/CartItem.java
+++ b/src/cartservice/cartservice-interface/src/main/java/com/alibabacloud/hipstershop/CartItem.java
@@ -1,6 +1,7 @@
 package com.alibabacloud.hipstershop;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * @author wangtao 2019-08-14 16:35
@@ -66,5 +67,18 @@ public class CartItem implements Serializable {
             ", productPicture='" + productPicture + '\'' +
             ", price=" + price +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CartItem item = (CartItem) o;
+        return productID.equals(item.productID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productID);
     }
 }

--- a/src/cartservice/cartservice-provider/pom.xml
+++ b/src/cartservice/cartservice-provider/pom.xml
@@ -43,6 +43,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
@@ -61,6 +69,10 @@
         <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
         </dependency>
         <dependency>
             <groupId>com.alibabacloud.hipstershop</groupId>

--- a/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/domain/RedisKey.java
+++ b/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/domain/RedisKey.java
@@ -1,0 +1,44 @@
+package com.alibabacloud.hipstershop.provider.domain;
+
+import java.util.ArrayList;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+public class RedisKey {
+    private ArrayList<String> keys;
+
+    public String getKey(){
+        StringBuffer sb = new StringBuffer();
+        keys.forEach(key -> sb.append(key).append(":"));
+        sb.delete(sb.length() - 2, sb.length() - 1);
+        return sb.toString();
+    }
+
+    public RedisKey(String k1){
+        this.keys = new ArrayList<>();
+        this.keys.add(k1);
+    }
+
+    public RedisKey(String k1, String k2){
+        this.keys = new ArrayList<>();
+        this.keys.add(k1);
+        this.keys.add(k2);
+    }
+
+    public RedisKey(String k1, String k2, String k3){
+        this.keys = new ArrayList<>();
+        this.keys.add(k1);
+        this.keys.add(k2);
+        this.keys.add(k3);
+    }
+
+    public RedisKey(String k1, String k2, String k3, String k4){
+        this.keys = new ArrayList<>();
+        this.keys.add(k1);
+        this.keys.add(k2);
+        this.keys.add(k3);
+        this.keys.add(k4);
+    }
+}

--- a/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/entity/Cart.java
+++ b/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/entity/Cart.java
@@ -1,0 +1,14 @@
+package com.alibabacloud.hipstershop.provider.entity;
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+
+public class Cart {
+    private String cartId;
+    private String productId;
+    private int quantity;
+    private String productName;
+    private String productPicture;
+    private int price;
+}

--- a/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/repository/RedisRepository.java
+++ b/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/repository/RedisRepository.java
@@ -1,0 +1,46 @@
+package com.alibabacloud.hipstershop.provider.repository;
+
+import com.alibabacloud.hipstershop.CartItem;
+import com.alibabacloud.hipstershop.provider.utils.Common;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+@Service
+public class RedisRepository {
+
+    @Resource
+    RedisTemplate<String, CartItem> redisTemplate;
+
+    public boolean save(CartItem cartItem, String userId){
+        String key = Common.getRedisKey(userId).getKey();
+        if(Objects.requireNonNull(redisTemplate.opsForSet().isMember(key, cartItem))){
+            List<CartItem> cartItems = getUserCartItems(userId);
+            CartItem cartItem2 = cartItems.stream()
+                    .filter(cartItem1 -> cartItem1.equals(cartItem)).findFirst().orElse(null);
+            Objects.requireNonNull(cartItem)
+                    .setQuantity(Objects.requireNonNull(cartItem2).getQuantity() + cartItem.getQuantity());
+        }
+        redisTemplate.opsForSet().add(key, cartItem);
+        return true;
+    }
+
+    public List<CartItem> getUserCartItems(String userId){
+        return new ArrayList<>(Objects.requireNonNull(redisTemplate.opsForSet().members(Common.getRedisKey(userId).getKey())));
+    }
+
+    public boolean removeUserCartItems(String userId){
+        //移除购物车商品
+        redisTemplate.delete(Common.getRedisKey(userId).getKey());
+        return true;
+    }
+
+}

--- a/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/utils/Common.java
+++ b/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/utils/Common.java
@@ -1,0 +1,13 @@
+package com.alibabacloud.hipstershop.provider.utils;
+
+import com.alibabacloud.hipstershop.provider.domain.RedisKey;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+public class Common {
+    public static RedisKey getRedisKey(String userId){
+        return new RedisKey(Constant.REDIS_CART, userId);
+    }
+}

--- a/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/utils/Constant.java
+++ b/src/cartservice/cartservice-provider/src/main/java/com/alibabacloud/hipstershop/provider/utils/Constant.java
@@ -1,0 +1,9 @@
+package com.alibabacloud.hipstershop.provider.utils;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+public class Constant {
+    public static String REDIS_CART = "cart";
+}

--- a/src/cartservice/cartservice-provider/src/main/resources/application.properties
+++ b/src/cartservice/cartservice-provider/src/main/resources/application.properties
@@ -1,5 +1,17 @@
 # Spring boot application
 spring.application.name=cartservice
+
+#database
+spring.redis.database=0
+#spring.redis.password=123
+spring.redis.port=6379
+spring.redis.host=cart-redis
+spring.redis.lettuce.pool.min-idle=5
+spring.redis.lettuce.pool.max-idle=10
+spring.redis.lettuce.pool.max-active=8
+spring.redis.lettuce.pool.max-wait=1ms
+spring.redis.lettuce.shutdown-timeout=100ms
+
 # Base packages to scan Dubbo Component: @org.apache.dubbo.config.annotation.Service
 dubbo.scan.base-packages=com.alibabacloud.hipstershop.provider
 

--- a/src/checkoutservice/checkoutservice-api/pom.xml
+++ b/src/checkoutservice/checkoutservice-api/pom.xml
@@ -14,4 +14,12 @@
 
     <name>${project.artifactId}</name>
     <description>The api module for payment service</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibabacloud.hipstershop</groupId>
+            <artifactId>productservice-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/checkoutservice/checkoutservice-api/src/main/java/com/alibabacloud/hipstershop/checkoutserviceapi/domain/Order.java
+++ b/src/checkoutservice/checkoutservice-api/src/main/java/com/alibabacloud/hipstershop/checkoutserviceapi/domain/Order.java
@@ -1,8 +1,12 @@
 package com.alibabacloud.hipstershop.checkoutserviceapi.domain;
 
+import com.alibabacloud.hipstershop.domain.ProductItem;
+
 import java.io.Serializable;
+import java.util.List;
 
 /**
+ * 订单对象，用于通信
  * @author xiaofeng.gxf
  * @date 2020/6/24
  */
@@ -13,6 +17,8 @@ public class Order implements Serializable {
     private Double shipCost;
     private Double productCost;
     private Double totalCost;
+    private List<ProductItem> productItemList;
+    private Integer status;
 
     public String getOrderId() {
         return orderId;
@@ -62,16 +68,34 @@ public class Order implements Serializable {
         this.totalCost = totalCost;
     }
 
+    public List<ProductItem> getProductItemList() {
+        return productItemList;
+    }
+
+    public void setProductItemList(List<ProductItem> productItemList) {
+        this.productItemList = productItemList;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
     public Order() {
     }
 
-    public Order(String orderId, String shipId, String userId, Double shipCost, Double productCost, Double totalCost) {
+    public Order(String orderId, String shipId, String userId, Double shipCost, Double productCost, Double totalCost, List<ProductItem> productItemList, Integer status) {
         this.orderId = orderId;
         this.shipId = shipId;
         this.userId = userId;
         this.shipCost = shipCost;
         this.productCost = productCost;
         this.totalCost = totalCost;
+        this.productItemList = productItemList;
+        this.status = status;
     }
 
     @Override

--- a/src/checkoutservice/checkoutservice-provider/pom.xml
+++ b/src/checkoutservice/checkoutservice-provider/pom.xml
@@ -48,6 +48,14 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-cloud-starter-dubbo</artifactId>
         </dependency>

--- a/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/entity/OrderForm.java
+++ b/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/entity/OrderForm.java
@@ -1,0 +1,139 @@
+package com.alibabacloud.hipstershop.checkoutservice.entity;
+
+import com.alibabacloud.hipstershop.checkoutservice.utils.JsonUtils;
+import com.alibabacloud.hipstershop.checkoutserviceapi.domain.Order;
+import com.alibabacloud.hipstershop.domain.ProductItem;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.List;
+
+/**
+ *
+ *Pojo,对应于数据库表
+ *
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+@Entity
+public class OrderForm {
+    @Id
+    @Column(nullable = false, columnDefinition = "varchar(100)")
+    private String orderId;
+    private String shipId;
+    private String userId;
+    private Double shipCost;
+    private Double productCost;
+    private Double totalCost;
+    private Integer status;
+    @Column(nullable = false, columnDefinition = "varchar(2000)")
+    private String productList;
+
+    public OrderForm(){}
+
+    public OrderForm(Order order){
+        this.orderId = order.getOrderId();
+        this.shipId = order.getShipId();
+        this.userId = order.getUserId();
+        this.shipCost = order.getShipCost();
+        this.productCost = order.getProductCost();
+        this.totalCost = order.getTotalCost();
+        this.status = order.getStatus();
+        try {
+            this.productList = JsonUtils.objectMapper.writeValueAsString(order.getProductItemList());
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            this.productList = "";
+        }
+    }
+
+    /**
+     * 将OrderForm转化为Order对象
+     * @return order对象
+     */
+    public Order getOrder(){
+        Order order = new Order();
+        order.setOrderId(this.orderId);
+        order.setShipId(this.shipId);
+        order.setUserId(this.userId);
+        order.setShipCost(this.shipCost);
+        order.setProductCost(this.productCost);
+        order.setTotalCost(this.totalCost);
+        order.setStatus(this.status);
+        try {
+            order.setProductItemList(JsonUtils.objectMapper.readValue(this.productList,
+                    new TypeReference<List<ProductItem>>() {}));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            order.setProductItemList(null);
+        }
+        return order;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public String getShipId() {
+        return shipId;
+    }
+
+    public void setShipId(String shipId) {
+        this.shipId = shipId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public Double getShipCost() {
+        return shipCost;
+    }
+
+    public void setShipCost(Double shipCost) {
+        this.shipCost = shipCost;
+    }
+
+    public Double getProductCost() {
+        return productCost;
+    }
+
+    public void setProductCost(Double productCost) {
+        this.productCost = productCost;
+    }
+
+    public Double getTotalCost() {
+        return totalCost;
+    }
+
+    public void setTotalCost(Double totalCost) {
+        this.totalCost = totalCost;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getProductList() {
+        return productList;
+    }
+
+    public void setProductList(String productList) {
+        this.productList = productList;
+    }
+}

--- a/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/repository/OrderFormRepository.java
+++ b/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/repository/OrderFormRepository.java
@@ -1,0 +1,14 @@
+package com.alibabacloud.hipstershop.checkoutservice.repository;
+
+import com.alibabacloud.hipstershop.checkoutservice.entity.OrderForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+@Repository
+public interface OrderFormRepository extends JpaRepository<OrderForm, String> {
+
+}

--- a/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/service/CheckoutServiceImpl.java
+++ b/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/service/CheckoutServiceImpl.java
@@ -2,6 +2,8 @@ package com.alibabacloud.hipstershop.checkoutservice.service;
 
 import com.alibabacloud.hipstershop.CartItem;
 import com.alibabacloud.hipstershop.CartService;
+import com.alibabacloud.hipstershop.checkoutservice.entity.OrderForm;
+import com.alibabacloud.hipstershop.checkoutservice.repository.OrderFormRepository;
 import com.alibabacloud.hipstershop.checkoutserviceapi.domain.Order;
 import com.alibabacloud.hipstershop.checkoutserviceapi.service.CheckoutService;
 import com.alibabacloud.hipstershop.domain.ProductItem;
@@ -11,8 +13,10 @@ import org.apache.dubbo.config.annotation.Service;
 import org.apache.dubbo.config.spring.context.annotation.DubboComponentScan;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 
+import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -32,9 +36,11 @@ public class CheckoutServiceImpl implements CheckoutService {
     private ProductService productService;
 
     /**
-     * 临时存储订单
-     */
-    ConcurrentHashMap<String, Order> orderStore = new ConcurrentHashMap<>();
+     * orderForm数据库操作接口
+     *
+     * */
+    @Resource
+    private OrderFormRepository orderFormRepository;
 
     @Override
     public String checkout(String email, String streetAddress, String zipCode, String city, String state,
@@ -57,37 +63,49 @@ public class CheckoutServiceImpl implements CheckoutService {
             //校验库存
             List<ProductItem> lockedProductItems = productService.confirmInventory(productItems);
 
-            //计算价格
+            //保存商品列表
+            order.setProductItemList(productItems);
 
-            //校验、保存地址
+            int lockedProductNum = 0;
+            for(ProductItem item : lockedProductItems){
+                if(item.isLock()){
+                    lockedProductNum++;
+                }
+            }
 
-            //生成订单，支付
+            if(lockedProductNum > 0) {
+                //状态为1表示至少有一件商品购买成功。
+                order.setStatus(1);
 
-            //运输商品
+                //计算价格
 
-            //临时模拟
-            order.setShipId("123");
-            order.setProductCost(123.0);
-            order.setShipCost(123.0);
-            order.setTotalCost(246.0);
+                //校验、保存地址
+
+                //生成订单，支付
+
+                //运输商品
+
+            }
+            else {
+                //状态为2表示所有商品都购买失败。
+                order.setStatus(-1);
+                //临时模拟
+                order.setShipId(null);
+                order.setProductCost(0.0);
+                order.setShipCost(0.0);
+                order.setTotalCost(0.0);
+            }
         } catch (Exception e){
             e.printStackTrace();
             return "";
         }
-
-        orderStore.put(order.getOrderId(), order);
-
+        orderFormRepository.save(new OrderForm(order));
         return order.getOrderId();
     }
 
     @Override
     public Order getOrder(String orderId, String userId) {
-        if(orderStore.containsKey(orderId)){
-            Order order = orderStore.get(orderId);
-            if(order.getUserId().equals(userId)){
-                return order;
-            }
-        }
-        return null;
+        Optional<OrderForm> orderFormOptional = orderFormRepository.findById(orderId);
+        return orderFormOptional.orElse(new OrderForm()).getOrder();
     }
 }

--- a/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/utils/JsonUtils.java
+++ b/src/checkoutservice/checkoutservice-provider/src/main/java/com/alibabacloud/hipstershop/checkoutservice/utils/JsonUtils.java
@@ -1,0 +1,11 @@
+package com.alibabacloud.hipstershop.checkoutservice.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+public class JsonUtils {
+    public static ObjectMapper objectMapper = new ObjectMapper();
+}

--- a/src/checkoutservice/checkoutservice-provider/src/main/resources/application.properties
+++ b/src/checkoutservice/checkoutservice-provider/src/main/resources/application.properties
@@ -1,4 +1,13 @@
 spring.application.name=checkoutservice
+
+#database
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://checkout-mysql:3306/checkout?characterEncoding=utf8&useSSL=false
+spring.datasource.username=root
+spring.datasource.password=checkoutservice
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
 # Base packages to scan Dubbo Component: @org.apache.dubbo.config.annotation.Service
 dubbo.scan.base-packages=com.alibabacloud.hipstershop.checkoutservice.service
 # Dubbo Application

--- a/src/currencyservice/currencyservice-api/src/main/java/com/alibabacloud/hipstershop/checkoutserviceapi/service/CurrencyService.java
+++ b/src/currencyservice/currencyservice-api/src/main/java/com/alibabacloud/hipstershop/checkoutserviceapi/service/CurrencyService.java
@@ -1,0 +1,32 @@
+package com.alibabacloud.hipstershop.checkoutserviceapi.service;
+
+import com.alibabacloud.hipstershop.currencyserviceapi.domain.Currency;
+
+import java.util.List;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/6
+ */
+public interface CurrencyService {
+    /**
+     * 获取目前所有的货币种类
+     * @return currency对象组成的list。
+     */
+    List<Currency> getAllCurrency();
+
+    /**
+     * 获得用户默认货币选项
+     * @param userId 用户Id
+     * @return 用户默认货币种类
+     */
+    Currency getCurrency(String userId);
+
+    /**
+     * 更新用户默认货币选项
+     * @param userId 用户Id
+     * @param currencyCode 货币标志码
+     * @return 更换之后的货币种类
+     */
+    Currency updateCurrency(String userId, String currencyCode);
+}

--- a/src/currencyservice/currencyservice-api/src/main/java/com/alibabacloud/hipstershop/currencyserviceapi/domain/Currency.java
+++ b/src/currencyservice/currencyservice-api/src/main/java/com/alibabacloud/hipstershop/currencyserviceapi/domain/Currency.java
@@ -1,0 +1,19 @@
+package com.alibabacloud.hipstershop.currencyserviceapi.domain;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/6
+ */
+public class Currency {
+    private String currencyCode;
+    private String country;
+    private String symbol;
+    private Double exchangeRate;
+
+    public Currency(String currencyCode, String country, String symbol, Double exchangeRate) {
+        this.currencyCode = currencyCode;
+        this.country = country;
+        this.symbol = symbol;
+        this.exchangeRate = exchangeRate;
+    }
+}

--- a/src/currencyservice/currencyservice-provider/pom.xml
+++ b/src/currencyservice/currencyservice-provider/pom.xml
@@ -44,6 +44,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>

--- a/src/currencyservice/currencyservice-provider/src/main/java/com/alibabacloud/hipstershop/currencyservice/domain/UserCurrency.java
+++ b/src/currencyservice/currencyservice-provider/src/main/java/com/alibabacloud/hipstershop/currencyservice/domain/UserCurrency.java
@@ -1,0 +1,35 @@
+package com.alibabacloud.hipstershop.currencyservice.domain;
+
+/**
+ *
+ * 用户默认货币
+ * 后续改进为持久化存储
+ *
+ * @author xiaofeng.gxf
+ * @date 2020/7/6
+ */
+public class UserCurrency {
+    private String userId;
+    private String currencyCode;
+
+    public UserCurrency(String userId, String currencyCode) {
+        this.userId = userId;
+        this.currencyCode = currencyCode;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public void setCurrencyCode(String currencyCode) {
+        this.currencyCode = currencyCode;
+    }
+}

--- a/src/currencyservice/currencyservice-provider/src/main/java/com/alibabacloud/hipstershop/currencyservice/service/CurrencyServiceImpl.java
+++ b/src/currencyservice/currencyservice-provider/src/main/java/com/alibabacloud/hipstershop/currencyservice/service/CurrencyServiceImpl.java
@@ -1,0 +1,53 @@
+package com.alibabacloud.hipstershop.currencyservice.service;
+
+import com.alibabacloud.hipstershop.currencyservice.domain.UserCurrency;
+import com.alibabacloud.hipstershop.currencyserviceapi.domain.Currency;
+import com.alibabacloud.hipstershop.checkoutserviceapi.service.CurrencyService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/6
+ */
+@Service
+public class CurrencyServiceImpl implements CurrencyService {
+
+    /**
+     * 临时存储货币
+     */
+    ConcurrentHashMap<String, Currency> currencyConcurrentHashMap = new ConcurrentHashMap<>();
+
+    /**
+     * 临时存储用户默认货币类型,键为 userId,值为 UserCurrency
+     */
+    ConcurrentHashMap<String, UserCurrency> userCurrencyConcurrentHashMap = new ConcurrentHashMap<>();
+
+    public CurrencyServiceImpl(){
+        Currency yuan = new Currency("CNY", "China", "￥", 1.0);
+        Currency dollar = new Currency("USD", "USA", "$", 7.01);
+        currencyConcurrentHashMap.put("CNY", yuan);
+        currencyConcurrentHashMap.put("USD", dollar);
+    }
+
+    @Override
+    public List<Currency> getAllCurrency() {
+        return (List<Currency>) currencyConcurrentHashMap.values();
+    }
+
+    @Override
+    public Currency getCurrency(String userId) {
+        if(!userCurrencyConcurrentHashMap.containsKey(userId)){
+            userCurrencyConcurrentHashMap.put(userId, new UserCurrency(userId, "CNY"));
+        }
+        return currencyConcurrentHashMap.get(userCurrencyConcurrentHashMap.get(userId).getCurrencyCode());
+    }
+
+    @Override
+    public Currency updateCurrency(String userId, String currencyCode) {
+        userCurrencyConcurrentHashMap.put(userId, new UserCurrency(userId, currencyCode));
+        return currencyConcurrentHashMap.get(currencyCode);
+    }
+}

--- a/src/currencyservice/currencyservice-provider/src/main/resources/application.properties
+++ b/src/currencyservice/currencyservice-provider/src/main/resources/application.properties
@@ -1,5 +1,14 @@
 # Spring boot application
 spring.application.name=currencyservice
+
+# database
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://currency-mysql:3306/currency?characterEncoding=utf8&useSSL=false
+spring.datasource.username=root
+spring.datasource.password=currencyservice
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
 # Base packages to scan Dubbo Component: @org.apache.dubbo.config.annotation.Service
 dubbo.scan.base-packages=com.alibabacloud.hipstershop.currencyservice
 # Dubbo Application
@@ -15,3 +24,4 @@ dubbo.consumer.check=false
 dubbo.registry.check=false
 dubbo.application.qos-enable=true
 dubbo.application.qos-accept-foreign-ip=false
+

--- a/src/frontend/src/main/java/com/alibabacloud/hipstershop/web/CheckoutTestsController.java
+++ b/src/frontend/src/main/java/com/alibabacloud/hipstershop/web/CheckoutTestsController.java
@@ -1,0 +1,38 @@
+package com.alibabacloud.hipstershop.web;
+
+import com.alibabacloud.hipstershop.dao.OrderDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+import javax.annotation.Resource;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/9
+ */
+@RestController
+public class CheckoutTestsController {
+
+    @Resource
+    private OrderDAO orderDAO;
+
+    private String userID = "Test User";
+
+    @PostMapping("/checkout_test")
+    public String checkout(@RequestParam(name="email") String email,
+                                 @RequestParam(name="street_address") String streetAddress,
+                                 @RequestParam(name="zip_code") String zipCode,
+                                 @RequestParam(name="city") String city,
+                                 @RequestParam(name="state") String state,
+                                 @RequestParam(name="credit_card_number") String creditCardNumber,
+                                 @RequestParam(name="credit_card_expiration_month") int creditCardExpirationMonth,
+                                 @RequestParam(name="credit_card_cvv") String creditCardCvv) {
+        String orderId = orderDAO.checkout(email, streetAddress, zipCode, city, state, creditCardNumber,
+                creditCardExpirationMonth, creditCardCvv, userID);
+        return orderId;
+    }
+}

--- a/src/productservice/productservice-provider/pom.xml
+++ b/src/productservice/productservice-provider/pom.xml
@@ -42,6 +42,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/ProductServiceApplication.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/ProductServiceApplication.java
@@ -8,5 +8,4 @@ public class ProductServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(ProductServiceApplication.class, args);
     }
-
 }

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/controller/ProductController.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/controller/ProductController.java
@@ -1,90 +1,34 @@
 package com.alibabacloud.hipstershop.controller;
 
 import com.alibabacloud.hipstershop.domain.Product;
+import com.alibabacloud.hipstershop.entity.ProductInfo;
+import com.alibabacloud.hipstershop.service.ProductInfoServiceImpl;
+import com.alibabacloud.hipstershop.service.ProductServiceApi;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @RestController
 public class ProductController {
 
-    private List<Product> products = new ArrayList<>();
-
-    public ProductController() {
-        Product p1 = new Product();
-        p1.setId("OLJCESPC7Z");
-        p1.setName("Air Jordan 1 Mid SE 白绿 GS");
-        p1.setDescription("Air Jordan 1于1985年推出，是耐克第一双以乔丹名字命名的篮球鞋，正是这双鞋，开启了一个时代。");
-        p1.setPicture("/img/products/1.png");
-        p1.setPrice(1559);
-        p1.setCategories(Arrays.asList("shoe"));
-        products.add(p1);
-
-        Product p2 = new Product();
-        p2.setId("66VCHSJNUP");
-        p2.setName("Air Jordan Legacy 312");
-        p2.setDescription("Air Jordan Legacy 312 男子运动鞋饰有醒目的设计细节，旨在向 Michael Jordan 的传奇精神致敬。匠心设计依托现代手法将经典 Jordan 元素混搭。");
-        p2.setPicture("/img/products/2.png");
-        p2.setPrice(1099);
-        p2.setCategories(Arrays.asList("shoe"));
-        products.add(p2);
-
-        Product p3 = new Product();
-        p3.setId("1YMWWN1N4O");
-        p3.setName("adidas Yezezy Boost 350");
-        p3.setDescription("adidas Yeezy Boost 350 v2是迄今为止最受欢迎的Yeezy鞋之一。它采用弹性Primeknit鞋面和BOOST中底，而最醒目的细节是罗纹中底。");
-        p3.setPicture("/img/products/3.png");
-        p3.setPrice(1609);
-        p3.setCategories(Arrays.asList("shoe"));
-        products.add(p3);
-
-        Product p4 = new Product();
-        p4.setId("L9ECAV7KIM");
-        p4.setName("小飛俠阿童木");
-        p4.setDescription("手冢治虫（TEZUKA CHARACTERS）- 小飛俠阿童木與菇 -彩色漫畫版。");
-        p4.setPicture("/img/products/4.png");
-        p4.setPrice(1000);
-        p4.setCategories(Arrays.asList("toy"));
-        products.add(p4);
-
-        Product p5 = new Product();
-        p5.setId("2ZYFJ3GM2N");
-        p5.setName("宠物小精灵 超梦");
-        p5.setDescription("BAN DAI 万代 SHF 宠物小精灵 超梦 精灵宝可梦 Arts Remix。");
-        p5.setPicture("/img/products/5.png");
-        p5.setPrice(3000);
-        p5.setCategories(Arrays.asList("toy", "pockmongo"));
-        products.add(p5);
-
-        Product p6 = new Product();
-        p6.setId("0PUK6V6EV0");
-        p6.setName("变形金刚：大黄蜂");
-        p6.setDescription("threezero 《变形金刚：大黄蜂》- DLX比例合金版闪电 10.6寸。");
-        p6.setPicture("/img/products/6.png");
-        p6.setPrice(800);
-        p6.setCategories(Arrays.asList("toy"));
-        products.add(p6);
-    }
+    @Resource
+    ProductServiceApi productServiceApi;
 
     @GetMapping("/product/{id}")
     public Product getProductById(@PathVariable(name = "id") String id) {
-        for (Product p: products) {
-            if (p.getId().equals(id)) {
-                return p;
-            }
-        }
-        // TODO: avoid null value
-        return null;
+        return productServiceApi.getProduct(id).getProduct();
     }
 
     @GetMapping("/products")
     public List<Product> getProductList() {
-        return Collections.unmodifiableList(products);
+        return productServiceApi.getAllProduct().stream().map(ProductInfo::getProduct).collect(Collectors.toList());
     }
 }

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/entity/ProductInfo.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/entity/ProductInfo.java
@@ -1,0 +1,110 @@
+package com.alibabacloud.hipstershop.entity;
+
+import com.alibabacloud.hipstershop.domain.Product;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+@Entity
+public class ProductInfo {
+    /**
+     * 此处限定id长度为255是因为如果使用的mysql引擎为InnoDB时，索引长度大于191时会出错，设置字符集为UTF8时，长度最大为255
+     */
+    @Id
+    @Column(nullable = false, columnDefinition = "varchar(100)")
+    private String id;
+    private String name;
+    @Column(nullable = false, columnDefinition = "varchar(2000)")
+    private String description;
+    private String picture;
+    private int price;
+    @Column(nullable = false, columnDefinition = "varchar(2000)")
+    private String categories;
+
+    public ProductInfo(){}
+
+    public ProductInfo(Product product){
+        this.id = product.getId();
+        this.name = product.getName();
+        this.description = product.getDescription();
+        this.picture = product.getPicture();
+        this.price = product.getPrice();
+        StringBuffer sb = new StringBuffer();
+        product.getCategories().forEach(s -> sb.append(s).append(","));
+        this.categories = sb.toString();
+    }
+
+    public Product getProduct(){
+        Product product = new Product();
+        product.setId(id);
+        product.setName(name);
+        product.setDescription(description);
+        product.setPicture(picture);
+        product.setPrice(price);
+        String[] tags = categories.split(",");
+        List<String> strings = new ArrayList<>();
+        for(String s : tags){
+            if(!("").equals(s)){
+                strings.add(s);
+            }
+        }
+        product.setCategories(strings);
+        return product;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+
+    public void setPicture(String picture) {
+        this.picture = picture;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+
+    public String getCategories() {
+        return categories;
+    }
+
+    public void setCategories(String categories) {
+        this.categories = categories;
+    }
+
+}

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/init/InitData.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/init/InitData.java
@@ -1,0 +1,87 @@
+package com.alibabacloud.hipstershop.init;
+
+import com.alibabacloud.hipstershop.domain.Product;
+import com.alibabacloud.hipstershop.entity.ProductInfo;
+import com.alibabacloud.hipstershop.repository.ProductInfoRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/10
+ */
+@Component
+public class InitData implements ApplicationRunner {
+    @Resource
+    ProductInfoRepository productInfoRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        List<ProductInfo> productInfoList = new ArrayList<>();
+        Product p1 = new Product();
+        p1.setId("OLJCESPC7Z");
+        p1.setName("Air Jordan 1 Mid SE 白绿 GS");
+        p1.setDescription("Air Jordan 1于1985年推出，是耐克第一双以乔丹名字命名的篮球鞋，正是这双鞋，开启了一个时代。");
+        p1.setPicture("/img/products/1.png");
+        p1.setPrice(1559);
+        p1.setCategories(Collections.singletonList("shoe"));
+        productInfoList.add(new ProductInfo(p1));
+
+        Product p2 = new Product();
+        p2.setId("66VCHSJNUP");
+        p2.setName("Air Jordan Legacy 312");
+        p2.setDescription("Air Jordan Legacy 312 男子运动鞋饰有醒目的设计细节，旨在向 Michael Jordan 的传奇精神致敬。匠心设计依托现代手法将经典 Jordan 元素混搭。");
+        p2.setPicture("/img/products/2.png");
+        p2.setPrice(1099);
+        p2.setCategories(Collections.singletonList("shoe"));
+        productInfoList.add(new ProductInfo(p2));
+
+        Product p3 = new Product();
+        p3.setId("1YMWWN1N4O");
+        p3.setName("adidas Yezezy Boost 350");
+        p3.setDescription("adidas Yeezy Boost 350 v2是迄今为止最受欢迎的Yeezy鞋之一。它采用弹性Primeknit鞋面和BOOST中底，而最醒目的细节是罗纹中底。");
+        p3.setPicture("/img/products/3.png");
+        p3.setPrice(1609);
+        p3.setCategories(Collections.singletonList("shoe"));
+        productInfoList.add(new ProductInfo(p3));
+
+        Product p4 = new Product();
+        p4.setId("L9ECAV7KIM");
+        p4.setName("小飛俠阿童木");
+        p4.setDescription("手冢治虫（TEZUKA CHARACTERS）- 小飛俠阿童木與菇 -彩色漫畫版。");
+        p4.setPicture("/img/products/4.png");
+        p4.setPrice(1000);
+        p4.setCategories(Collections.singletonList("toy"));
+        productInfoList.add(new ProductInfo(p4));
+
+        Product p5 = new Product();
+        p5.setId("2ZYFJ3GM2N");
+        p5.setName("宠物小精灵 超梦");
+        p5.setDescription("BAN DAI 万代 SHF 宠物小精灵 超梦 精灵宝可梦 Arts Remix。");
+        p5.setPicture("/img/products/5.png");
+        p5.setPrice(3000);
+        p5.setCategories(Arrays.asList("toy", "pockmongo"));
+        productInfoList.add(new ProductInfo(p5));
+
+        Product p6 = new Product();
+        p6.setId("0PUK6V6EV0");
+        p6.setName("变形金刚：大黄蜂");
+        p6.setDescription("threezero 《变形金刚：大黄蜂》- DLX比例合金版闪电 10.6寸。");
+        p6.setPicture("/img/products/6.png");
+        p6.setPrice(800);
+        p6.setCategories(Collections.singletonList("toy"));
+        productInfoList.add(new ProductInfo(p6));
+        try {
+            productInfoRepository.saveAll(productInfoList);
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/repository/ProductInfoRepository.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/repository/ProductInfoRepository.java
@@ -1,0 +1,12 @@
+package com.alibabacloud.hipstershop.repository;
+
+import com.alibabacloud.hipstershop.entity.ProductInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @author xiaofeng.gxf
+ * @date 2020/7/7
+ */
+public interface ProductInfoRepository extends JpaRepository<ProductInfo, String> {
+
+}

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/service/ProductInfoServiceImpl.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/service/ProductInfoServiceImpl.java
@@ -1,0 +1,32 @@
+package com.alibabacloud.hipstershop.service;
+
+import com.alibabacloud.hipstershop.entity.ProductInfo;
+import com.alibabacloud.hipstershop.repository.ProductInfoRepository;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 对内的product service实现类。
+ * @author xiaofeng.gxf
+ * @date 2020/7/8
+ */
+@Service
+public class ProductInfoServiceImpl implements ProductServiceApi{
+
+    @Resource
+    ProductInfoRepository productInfoRepository;
+
+    @Override
+    public ProductInfo getProduct(String id) {
+        Optional<ProductInfo> productInfo = productInfoRepository.findById(id);
+        return productInfo.orElse(null);
+    }
+
+    @Override
+    public List<ProductInfo> getAllProduct() {
+        return productInfoRepository.findAll();
+    }
+}

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/service/ProductServiceApi.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/service/ProductServiceApi.java
@@ -1,0 +1,25 @@
+package com.alibabacloud.hipstershop.service;
+
+import com.alibabacloud.hipstershop.entity.ProductInfo;
+
+import java.util.List;
+
+/**
+ * 对内的 product service 接口。
+ * @author xiaofeng.gxf
+ * @date 2020/7/8
+ */
+public interface ProductServiceApi {
+    /**
+     * 根据商品Id查询商品
+     * @param id 商品Id
+     * @return 对应的商品
+     */
+    ProductInfo getProduct(String id);
+
+    /**
+     * 获取所有商品
+     * @return 所有商品列表
+     */
+    List<ProductInfo> getAllProduct();
+}

--- a/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/service/ProductServiceImpl.java
+++ b/src/productservice/productservice-provider/src/main/java/com/alibabacloud/hipstershop/service/ProductServiceImpl.java
@@ -1,6 +1,7 @@
 package com.alibabacloud.hipstershop.service;
 
 import com.alibabacloud.hipstershop.domain.ProductItem;
+import com.alibabacloud.hipstershop.entity.ProductInfo;
 import org.apache.dubbo.config.annotation.Service;
 import org.apache.dubbo.config.spring.context.annotation.DubboComponentScan;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -8,6 +9,7 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import java.util.List;
 
 /**
+ * 对外提供的Dubbo service实现类
  * @author xiaofeng.gxf
  * @date 2020/6/29
  */
@@ -15,7 +17,7 @@ import java.util.List;
 @DubboComponentScan
 @RefreshScope
 @Service(version = "1.0.0")
-public class ProductServiceImpl implements ProductService {
+public class ProductServiceImpl implements ProductService{
 
     @Override
     public List<ProductItem> confirmInventory(List<ProductItem> checkoutProductItems) {

--- a/src/productservice/productservice-provider/src/main/resources/application.properties
+++ b/src/productservice/productservice-provider/src/main/resources/application.properties
@@ -1,4 +1,13 @@
 spring.application.name=productservice
+
+#database
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://product-mysql:3306/product?characterEncoding=utf8&useSSL=false
+spring.datasource.username=root
+spring.datasource.password=productservice
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
 # Base packages to scan Dubbo Component: @org.apache.dubbo.config.annotation.Service
 dubbo.scan.base-packages=com.alibabacloud.hipstershop.service
 # Dubbo Application

--- a/src/productservice/productservice-provider/src/main/resources/backup.sql
+++ b/src/productservice/productservice-provider/src/main/resources/backup.sql
@@ -1,0 +1,6 @@
+insert into product_info(id, name, description, picture, price, categories) values ('OLJCESPC7Z', 'Air Jordan 1 Mid SE 白绿 GS', 'Air Jordan 1于1985年推出，是耐克第一双以乔丹名字命名的篮球鞋，正是这双鞋，开启了一个时代。','/img/products/1.png', 1559, 'shoe');
+insert into product_info(id, name, description, picture, price, categories) values ('66VCHSJNUP', 'Air Jordan Legacy 312', 'Air Jordan Legacy 312 男子运动鞋饰有醒目的设计细节，旨在向 Michael Jordan 的传奇精神致敬。匠心设计依托现代手法将经典 Jordan 元素混搭。','/img/products/2.png', 1099, 'shoe');
+insert into product_info(id, name, description, picture, price, categories) values ('1YMWWN1N4O', 'adidas Yezezy Boost 350', 'adidas Yeezy Boost 350 v2是迄今为止最受欢迎的Yeezy鞋之一。它采用弹性Primeknit鞋面和BOOST中底，而最醒目的细节是罗纹中底。','/img/products/3.png', 1609, 'shoe');
+insert into product_info(id, name, description, picture, price, categories) values ('L9ECAV7KIM', '小飞侠阿童木', '手冢治虫（TEZUKA CHARACTERS）- 小飞侠阿童木 -彩色漫画版。','/img/products/4.png', 1000, 'toy');
+insert into product_info(id, name, description, picture, price, categories) values ('2ZYFJ3GM2N', '宠物小精灵 超梦', 'BAN DAI 万代 SHF 宠物小精灵 超梦 精灵宝可梦 Arts Remix。','/img/products/5.png', 3000, 'toy,pockmongo');
+insert into product_info(id, name, description, picture, price, categories) values ('0PUK6V6EV0', '变形金刚：大黄蜂', 'threezero 《变形金刚：大黄蜂》- DLX比例合金版闪电 10.6寸。','/img/products/6.png', 800, 'toy');


### PR DESCRIPTION
1. Add mysql for checkoutservice and productservice.
2. Add redis for cartservice.
3. Add checkout_test interface for testing checkout.

Because the previous entity classes were all in the `[service name]-api` , I added a similar entity class in the `[service name]-provider` for database support, with the former as a `DTO` and the latter as a `PO`, providing functions to convert to each other.

Also, because of the added mysql and redis, it is necessary to start the deployment and service in the `db.yaml` at `kubernetes-manifests/quick-start` to ensure that applications start correctly on k8s cluster.
