### PR TITLE
specifies the python image version

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim as base
+FROM python:3.6-slim as base
 
 FROM base as builder
 


### PR DESCRIPTION
问题描述：
在构建loadgenerator时，会出现**gevent**依赖安装失败的错误。

原因：
在loadgenerator的Dockerfile中，仅仅指定了python版本为**3**，默认会拉取最新版本的的python镜像，而requirements.txt中指定的**gevent**版本为**1.4.0**。该版本的**gevent**不支持**3.6**以上版本的python。

修复：
在Dockerfile中指定python镜像版本为**3.6**。