### PR TITLE
add missing kubernetes manifests for cart, checkout and product service

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -44,3 +44,18 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 6379
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cart-redis
+  name: cart-redis
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: cart-redis

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -53,3 +53,18 @@ spec:
           name: checkout-mysql
           ports:
             - containerPort: 3306
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: checkout-mysql
+  name: checkout-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+    app: checkout-mysql

--- a/kubernetes-manifests/productservice.yaml
+++ b/kubernetes-manifests/productservice.yaml
@@ -54,3 +54,18 @@ spec:
           name: product-mysql
           ports:
             - containerPort: 3306
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: product-mysql
+  name: product-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+    app: product-mysql


### PR DESCRIPTION
When I deploy this project to a kubernetes cluster according to this : 
> #### Deploy to Kubernetes cluster
> 
> This project can be deployed to Kubernetes cluster with the following command:
> 
> ```sh
> cd kubernetes-manifests/
> for i in *.yaml; do kubectl apply -f $i; done
> ```

kubernetes services like `cart-redis`, `checkout-mysql` and `product-mysql` are not successfully created in kubernetes cluster, which makes error in cart, checkout and product deployment.