### PR TITLE
fix schedule task print old value of name when nacos config update

### DIFF
--- a/mse-quickstart-demo/consumer/src/main/java/com/alibabacloud/mse/demo/AController.java
+++ b/mse-quickstart-demo/consumer/src/main/java/com/alibabacloud/mse/demo/AController.java
@@ -1,5 +1,6 @@
 package com.alibabacloud.mse.demo;
 
+import com.alibabacloud.mse.demo.bean.Consumer;
 import com.alibabacloud.mse.demo.service.HelloServiceB;
 import org.apache.dubbo.config.annotation.Reference;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,9 +27,9 @@ public class AController {
     @Reference(application = "${dubbo.application.id}", version = "1.0.0")
     private HelloServiceB helloServiceB;
 
-    @Value("${name:123}")
-    private String name;
 
+    @Autowired
+    private Consumer consumer;
 
     @Autowired
     RestTemplate restTemplate;
@@ -50,7 +51,7 @@ public class AController {
         EXECUTOR_SERVICE.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
-                System.out.println(name);
+                System.out.println(consumer.getName());
             }
         },0,2, TimeUnit.SECONDS);
     }

--- a/mse-quickstart-demo/consumer/src/main/java/com/alibabacloud/mse/demo/bean/Consumer.java
+++ b/mse-quickstart-demo/consumer/src/main/java/com/alibabacloud/mse/demo/bean/Consumer.java
@@ -1,0 +1,24 @@
+package com.alibabacloud.mse.demo.bean;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.stereotype.Component;
+
+/**
+ * @Author : zhaofei
+ * @create 2023/8/16 14:00
+ */
+@Component
+@RefreshScope
+@ConfigurationProperties()
+public class Consumer {
+    private String name = "123";
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Consumer subscribe and listen consumer.properties+DEFAULT_GROUP nacos config file. When nacos config file update, the schedule task still print the old value of name.